### PR TITLE
new encoding parameter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extensions = [
                          include_dirs=[np.get_include()], language='c++'),
 ]
 
-with open('README.md', 'r') as fh:
+with open('README.md', 'r', encoding='utf-8') as fh:
     long_description = fh.read()
 
 with open('requirements.txt', encoding='utf-8') as file:


### PR DESCRIPTION
Without the "encoding=utf-8" in the open function for the README.md file, the setup could not proceed. Specifying it should fix the issue.